### PR TITLE
Add experimental parser for alphabetical list of series

### DIFF
--- a/default.py
+++ b/default.py
@@ -37,7 +37,9 @@ import sledujufilmy
 
 settings = {'downloads': __addon__.getSetting('downloads'), 'quality': __addon__.getSetting('quality')}
 
+parser=__addon__.getSetting('parser')
+
 params = util.params()
 if params == {}:
     xbmcutil.init_usage_reporting(__scriptid__)
-xbmcprovider.XBMCMultiResolverContentProvider(sledujufilmy.SledujuFilmyContentProvider(), settings, __addon__).run(params)
+xbmcprovider.XBMCMultiResolverContentProvider(sledujufilmy.SledujuFilmyContentProvider(quickparser=parser), settings, __addon__).run(params)

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -20,4 +20,5 @@
 	<string id="30055">480p</string>
 	<string id="30056">360p</string>
 	<string id="31000">Data o použití jsou zaslána pouze v okamžiku, kdy spustíte přehrávání nebo stahování videa doplňkem.</string>
+	<string id="32000">Rychlý ale nestabilní parsovač</string>
 </strings>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -21,4 +21,5 @@
 	<string id="30055">480p</string>
 	<string id="30056">360p</string>
 	<string id="31000">Usage of plugin is tracked whenever you play or download video.</string>
+	<string id="32000">Fast but fragile parser (experimental)</string>
 </strings>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
+<strings>
+	<string id="30001">Video je nedostupné, skontrolujte,[CR]či funguje prehrávanie na webe.</string>
+	<string id="30003">[B]Najnovšie epizódy[/B]</string>
+	<string id="30004">Vyberte zdroj</string>
+
+	<string id="30030">Priečinok pre sťahovanie</string>
+	<string id="30031">Nastavte prosím priečinok pre sťahovanie</string>
+	<string id="30032">Zobrazovať stav sťahovania</string>
+	<string id="30033"> - zobraziť stav každých</string>
+	<string id="30034">10%</string>
+	<string id="30035">5%</string>
+	<string id="30036">1%</string>
+	<string id="30037">Stiahnuté súbory</string>
+	<string id="30050">Kvalita videa</string>
+	<string id="30051">Spýtať sa</string>
+	<string id="30052">Najlepšia</string>
+	<string id="30053">Najhoršia</string>
+	<string id="30054">720p</string>
+	<string id="30055">480p</string>
+	<string id="30056">360p</string>
+	<string id="31000">Údaje o použití sú zaslané iba v okamihu, keď spustíte prehrávanie alebo sťahovanie videa doplnkom.</string>
+	<string id="32000">Rýchly, no nestabilný parser</string>
+</strings>

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -4,4 +4,5 @@
 	<setting label="30030" id="downloads" type="folder" default="" />
 	<setting label="30032" id="download-notify" type="bool" default="true" />
 	<setting label="30033" id="download-notify-every" type="enum" lvalues="30034|30035|30036" default="0" visible="eq(-1,true)" />
+	<setting label="32000" id="parser" type="bool" default="false" />
 </settings>


### PR DESCRIPTION
Constructing BeautifulSoup objects is time-consuming on resource-limited
devices, such as Raspberry Pi. Using the default getting list of all
series takes up to 50 seconds on Raspberry Pi3.

This patch adds an experimental parser that breaks easily on website change
but OTOH it's able to do the same job in less than 9 seconds. The option
to use this parser (disabled by default) is also added to addon settings.
